### PR TITLE
(feat) O3-3504 : Implement the tutorial modal and listing tutorials

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -1,4 +1,4 @@
-import { Type, validator } from '@openmrs/esm-framework';
+import { Type } from '@openmrs/esm-framework';
 
 export const configSchema = {
   showTutorial: {
@@ -6,8 +6,37 @@ export const configSchema = {
     _default: false,
     _description: 'Enable or Disable Onboarding Walkthrough',
   },
+  tutorialData: {
+    _type: Type.Array,
+    _default: [
+      {
+        title: 'Sample Demo',
+        description:
+          'OpenMRS is a patient-centered medical record system that is designed to be flexible and extensible. It is a platform that supports a wide range of applications for use in low-resource settings. OpenMRS is a multi-institution, non-profit collaborative led by Regenstrief Institute, a world-renowned leader in medical informatics research, and Partners In Health, a Boston-based philanthropic organization.',
+      },
+      {
+        title: 'Tasks',
+        description:
+          'Find and organize what needs to be done for patients with task lists. Tasks are created both automatically based on data in the patient’s chart as well as manually by you or your colleagues.',
+      },
+      {
+        title: 'Order basket',
+        description: 'A single place for referral, imaging, drug and lab test orders.',
+      },
+      {
+        title: 'Patient lists',
+        description:
+          'Service queues help you manage your clinic. Patients can be organized by priority level and you can track the wait time for each of your clinic’s key areas.',
+      },
+    ],
+    _description: 'List of tutorials to be displayed in the modal',
+  },
 };
 
 export type Config = {
   showTutorial: boolean;
+  tutorialData: {
+    title: string;
+    description: string;
+  }[];
 };

--- a/src/tutorial/modal.component.tsx
+++ b/src/tutorial/modal.component.tsx
@@ -17,8 +17,8 @@ const TutorialModal = ({ open, onClose }) => {
       <div className={styles.tutorialModal}>
         {tutorialData.map((tutorial, index) => (
           <div className={styles.tutorialItem} key={index}>
-            <h3>{tutorial.title}</h3>
-            <p>{tutorial.description}</p>
+            <h3 className={styles.tutorialTitle}>{tutorial.title}</h3>
+            <p className={styles.tutorialDescription}>{tutorial.description}</p>
             <div className={styles.walkthrough}>{t('walkthrough', 'Walkthrough')}</div>
           </div>
         ))}

--- a/src/tutorial/modal.component.tsx
+++ b/src/tutorial/modal.component.tsx
@@ -1,41 +1,25 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, Modal } from '@carbon/react';
-
-const tutorialData = [
-  {
-    title: 'Patient search',
-    description:
-      'Quickly find patients by name, ID, or other identifiers. You can also search for patients by their attributes',
-  },
-  {
-    title: 'Tasks',
-    description:
-      'Find and organize what needs to be done for patients with task lists. Tasks are created both automatically based on data in the patient’s chart as well as manually by you or your colleagues.',
-  },
-  {
-    title: 'Order basket',
-    description: 'A single place for referral, imaging, drug and lab test orders.',
-  },
-  {
-    title: 'Patient lists',
-    description:
-      'Service queues help you manage your clinic. Patients can be organized by priority level and you can track the wait time for each of your clinic’s key areas.',
-  },
-];
+import { Modal } from '@carbon/react';
+import { useConfig } from '@openmrs/esm-framework';
+import styles from './styles.scss';
 
 const TutorialModal = ({ open, onClose }) => {
   const { t } = useTranslation();
+  const config = useConfig();
+  const tutorialData = config.tutorialData;
 
   return (
-    <Modal open={open} onRequestClose={onClose} passiveModal modalHeading={t('modalHeading', 'Tutorials')}>
-      <p>{t('modalDescription', 'Find walkthroughs and video tutorials on some of the core features of OpenMRS.')}</p>
-      <div>
+    <Modal open={open} onRequestClose={onClose} passiveModal modalHeading={t('tutorial', 'Tutorials')}>
+      <p className={styles.description}>
+        {t('modalDescription', 'Find walkthroughs and video tutorials on some of the core features of OpenMRS.')}
+      </p>
+      <div className={styles.tutorialModal}>
         {tutorialData.map((tutorial, index) => (
-          <div key={index}>
-            <h4>{t(`tutorials.${index}.title`, tutorial.title)}</h4>
-            <p>{t(`tutorials.${index}.description`, tutorial.description)}</p>
-            <a>{t('walkthrough', 'Walkthrough')}</a>
+          <div className={styles.tutorialItem} key={index}>
+            <h3>{tutorial.title}</h3>
+            <p>{tutorial.description}</p>
+            <div className={styles.walkthrough}>{t('walkthrough', 'Walkthrough')}</div>
           </div>
         ))}
       </div>

--- a/src/tutorial/modal.component.tsx
+++ b/src/tutorial/modal.component.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button, Modal } from '@carbon/react';
+
+const tutorialData = [
+  {
+    title: 'Patient search',
+    description:
+      'Quickly find patients by name, ID, or other identifiers. You can also search for patients by their attributes',
+  },
+  {
+    title: 'Tasks',
+    description:
+      'Find and organize what needs to be done for patients with task lists. Tasks are created both automatically based on data in the patient’s chart as well as manually by you or your colleagues.',
+  },
+  {
+    title: 'Order basket',
+    description: 'A single place for referral, imaging, drug and lab test orders.',
+  },
+  {
+    title: 'Patient lists',
+    description:
+      'Service queues help you manage your clinic. Patients can be organized by priority level and you can track the wait time for each of your clinic’s key areas.',
+  },
+];
+
+const TutorialModal = ({ open, onClose }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Modal open={open} onRequestClose={onClose} passiveModal modalHeading={t('modalHeading', 'Tutorials')}>
+      <p>{t('modalDescription', 'Find walkthroughs and video tutorials on some of the core features of OpenMRS.')}</p>
+      <div>
+        {tutorialData.map((tutorial, index) => (
+          <div key={index}>
+            <h4>{t(`tutorials.${index}.title`, tutorial.title)}</h4>
+            <p>{t(`tutorials.${index}.description`, tutorial.description)}</p>
+            <a>{t('walkthrough', 'Walkthrough')}</a>
+          </div>
+        ))}
+      </div>
+    </Modal>
+  );
+};
+
+export default TutorialModal;

--- a/src/tutorial/styles.scss
+++ b/src/tutorial/styles.scss
@@ -31,6 +31,7 @@
       margin-top: spacing.$spacing-03;
       color: $color-blue-60-2;
       font-size: 1rem;
+      @include type.type-style('body-compact-02');
     }
   }
 }

--- a/src/tutorial/styles.scss
+++ b/src/tutorial/styles.scss
@@ -30,7 +30,6 @@
       margin-bottom: spacing.$spacing-03;
       margin-top: spacing.$spacing-03;
       color: $color-blue-60-2;
-      font-size: 1rem;
       @include type.type-style('body-compact-02');
     }
   }

--- a/src/tutorial/styles.scss
+++ b/src/tutorial/styles.scss
@@ -3,25 +3,34 @@
 @import '~@openmrs/esm-styleguide/src/vars';
 
 .description {
-  margin-bottom: 1rem;
+  margin-bottom: spacing.$spacing-04;
+  @include type.type-style('body-compact-01');
 }
 
 .tutorialModal {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.$spacing-04;
+
   .tutorialItem {
-    margin-bottom: 2rem;
-    border-bottom: solid $ui-03;
-    padding-bottom: 1rem;
-  }
+    border-bottom: 1px solid $ui-03;
+    padding-bottom: spacing.$spacing-02;
 
-  .tutorialTitle {
-      font-size: 0.75rem;
-      font-weight: 400;
-      margin-bottom: 1rem;
+    .tutorialTitle {
+      margin-bottom: spacing.$spacing-04;
+      @include type.type-style('heading-02');
     }
-  .walkthrough {
-      gap: spacing.$spacing-02;
+
+    .tutorialDescription {
+      color: $color-gray-70;
+      @include type.type-style('body-compact-01');
+    }
+
+    .walkthrough {
+      margin-bottom: spacing.$spacing-03;
+      margin-top: spacing.$spacing-03;
       color: $color-blue-60-2;
-      cursor: pointer;
+      font-size: 1rem;
     }
   }
-
+}

--- a/src/tutorial/styles.scss
+++ b/src/tutorial/styles.scss
@@ -1,0 +1,27 @@
+@use '@carbon/styles/scss/spacing';
+@use '@carbon/styles/scss/type';
+@import '~@openmrs/esm-styleguide/src/vars';
+
+.description {
+  margin-bottom: 1rem;
+}
+
+.tutorialModal {
+  .tutorialItem {
+    margin-bottom: 2rem;
+    border-bottom: solid $ui-03;
+    padding-bottom: 1rem;
+  }
+
+  .tutorialTitle {
+      font-size: 0.75rem;
+      font-weight: 400;
+      margin-bottom: 1rem;
+    }
+  .walkthrough {
+      gap: spacing.$spacing-02;
+      color: $color-blue-60-2;
+      cursor: pointer;
+    }
+  }
+

--- a/src/tutorial/tutorial.tsx
+++ b/src/tutorial/tutorial.tsx
@@ -4,14 +4,14 @@ import Tutorials from './modal.component';
 
 const Tutorial = () => {
   const { t } = useTranslation();
-  const [isModalOpen, setModalOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleOpenModal = () => {
-    setModalOpen(true);
+    setIsModalOpen(true);
   };
 
   const handleCloseModal = () => {
-    setModalOpen(false);
+    setIsModalOpen(false);
   };
 
   return (

--- a/src/tutorial/tutorial.tsx
+++ b/src/tutorial/tutorial.tsx
@@ -1,11 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-
+import Tutorials from './modal.component';
 
 const Tutorial = () => {
   const { t } = useTranslation();
+  const [isModalOpen, setModalOpen] = useState(false);
 
-  return <div >{t('tutorials', 'Tutorials')}</div>;
+  const handleOpenModal = () => {
+    setModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
+  };
+
+  return (
+    <div>
+      <div onClick={handleOpenModal}>{t('tutorials', 'Tutorials')}</div>
+      <Tutorials open={isModalOpen} onClose={handleCloseModal} />
+    </div>
+  );
 };
 
 export default Tutorial;

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,4 +1,6 @@
 {
   "welcome": "Welcome to OpenMRS!",
-  "tutorial": "Tutorials"
+  "tutorial": "Tutorials",
+  "modalDescription":"Find walkthroughs and video tutorials on some of the core features of OpenMRS.",
+  "walkthrough":"Walkthrough"
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->
This PR implements a `tutorial modal` when clicked on the tutorials from the help menu and lists all the defined tutorials there.



## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

https://github.com/openmrs/openmrs-esm-user-onboarding/assets/94985341/f53e369d-4c24-4d61-9498-9a96ae41c045



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->
[O3-3504
](https://openmrs.atlassian.net/browse/O3-3504)

## Other
<!-- Anything not covered above -->
<!-- *None* -->
[Zeplin Design ](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/62c6b9f6d3cea618db0836c8)
