### PR TITLE
(fix) O3-3896: Tutorials modal should use a standard Carbon modal component

### DIFF
--- a/e2e/specs/onboarding-test.spec.ts
+++ b/e2e/specs/onboarding-test.spec.ts
@@ -28,7 +28,7 @@ test('Basic Walkthrough', async ({ page }) => {
     await page
       .locator('li')
       .filter({ hasText: 'Basic Overview' })
-      .locator('button', { hasText: 'Walkthrough' })
+      .locator('a', { hasText: 'Walkthrough' })
       .click();
   });
 

--- a/src/tutorial/modal.component.tsx
+++ b/src/tutorial/modal.component.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { useConfig, useAppContext, navigate } from '@openmrs/esm-framework';
 import styles from './styles.scss';
 import { type TutorialContext } from '../types';
-import { ModalHeader, ModalBody, Button } from '@carbon/react';
+import { ModalHeader, ModalBody, Link } from '@carbon/react';
+import { ArrowRight } from '@carbon/react/icons';
 
 const TutorialModal = ({ open, onClose }) => {
   const { t } = useTranslation();
@@ -39,7 +40,7 @@ const TutorialModal = ({ open, onClose }) => {
 
   return (
     <React.Fragment>
-      <ModalHeader closeModal={onClose} title={t('tutorial', 'Tutorial')}>
+      <ModalHeader closeModal={onClose} title={t('tutorial', 'Tutorial')} className={styles.modalHeader}>
         <p className={styles.description}>
           {t('modalDescription', 'Find walkthroughs and video tutorials on some of the core features of OpenMRS.')}
         </p>
@@ -50,9 +51,10 @@ const TutorialModal = ({ open, onClose }) => {
             <li className={styles.tutorialItem} key={index}>
               <h3 className={styles.tutorialTitle}>{tutorial.title}</h3>
               <p className={styles.tutorialDescription}>{tutorial.description}</p>
-              <Button kind="ghost" onClick={() => handleWalkthroughClick(index)}>
+              <Link onClick={() => handleWalkthroughClick(index)} className={styles.tutorialLink} renderIcon={() => 
+                <ArrowRight aria-label="Arrow Right" />}>
                 {t('walkthrough', 'Walkthrough')}
-              </Button>
+              </Link>
             </li>
           ))}
         </ul>

--- a/src/tutorial/styles.scss
+++ b/src/tutorial/styles.scss
@@ -1,5 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
+@use '@carbon/layout';
 @import '~@openmrs/esm-styleguide/src/vars';
 
 .description {
@@ -26,5 +27,38 @@
       @include type.type-style('body-compact-01');
     }
 
+    .tutorialLink {
+      margin-bottom: spacing.$spacing-04;
+      margin-top: spacing.$spacing-04;
+      cursor: pointer;
+    }
+  }
+}
+
+.modalHeader {
+  :global {
+    .cds--modal-close-button {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      margin: 0;
+      margin-top: calc(-1 * #{layout.$spacing-05});
+    }
+
+    .cds--modal-close {
+      background-color: rgba(0, 0, 0, 0);
+
+      &:hover {
+        background-color: var(--cds-layer-hover);
+      }
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-content {
+      transform: translate(-4rem, 0.85rem);
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-caret {
+      transform: translate(-3.75rem, 1.25rem);
+    }
   }
 }

--- a/src/tutorial/tutorial.tsx
+++ b/src/tutorial/tutorial.tsx
@@ -8,6 +8,7 @@ const Tutorial = () => {
   const handleOpenModal = () => {
     const dispose = showModal('tutorial-modal', {
       onClose: () => dispose(),
+      size: 'sm',
     });
   };
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR implements a fix for the Tutorial Modal styling of the [Carbon Modal](https://react.carbondesignsystem.com/?path=/docs/components-composedmodal--overview) component.

## Screenshots
<!-- Required if you are making UI changes. -->
### Before
https://github.com/user-attachments/assets/0c6c0524-0ff4-44ce-89b4-8baa9935141c

### After
https://github.com/user-attachments/assets/4b5c8b76-5c36-4f2f-84ad-a232b288d212

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-3896
