### PR TITLE
(fix) O3-3890 Help menu (and menu items) should use a standard Carbon…

### DIFF
--- a/src/tutorial/styles.scss
+++ b/src/tutorial/styles.scss
@@ -28,3 +28,10 @@
 
   }
 }
+
+.tutorialMenuItem {
+  color: black !important;
+  &:focus {
+    outline: none;
+  }
+}

--- a/src/tutorial/tutorial.test.tsx
+++ b/src/tutorial/tutorial.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import '@testing-library/jest-dom';
+import { showModal } from "@openmrs/esm-framework";
+import Tutorial from "./tutorial";
+
+jest.mock('@openmrs/esm-framework', () => ({
+	showModal: jest.fn(),
+}))
+
+describe('Tutorial Component', () => {
+	it('renders the menu item with the correct label', () => {
+		render(<Tutorial />);
+
+		expect(screen.getByText(/Tutorials/i)).toBeInTheDocument();
+	})
+
+	it('calls showModal when the menu item is clicked', () => {
+		render(<Tutorial />);
+
+		const menuItem = screen.getByText(/Tutorials/i);
+		fireEvent.click(menuItem);
+
+		expect(showModal).toHaveBeenCalledWith('tutorial-modal', expect.any(Object))
+	})
+})

--- a/src/tutorial/tutorial.tsx
+++ b/src/tutorial/tutorial.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { showModal } from '@openmrs/esm-framework';
+import { MenuItem } from '@carbon/react';
+import styles from './styles.scss';
 
 const Tutorial = () => {
   const { t } = useTranslation();
@@ -13,7 +15,11 @@ const Tutorial = () => {
 
   return (
     <>
-      <div onClick={handleOpenModal}>{t('tutorials', 'Tutorials')}</div>
+      <MenuItem 
+        onClick={handleOpenModal}
+        label={t('tutorials', 'Tutorials')}
+        className={styles.tutorialMenuItem}
+      />
     </>
   );
 };


### PR DESCRIPTION
… menu

## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
I have updated the help menu to use standard carbon menu items. This PR is related to this PR, https://github.com/openmrs/openmrs-esm-core/pull/1164.

## Screenshots
Please find attached the screenshot.
<img width="164" alt="Screenshot 2024-09-26 at 16 45 40" src="https://github.com/user-attachments/assets/e4fb247e-f50b-43ad-a3e5-2b24e3648771">


## Related Issue
https://openmrs.atlassian.net/browse/O3-3890

## Other
<!-- Anything not covered above -->
<!-- *None* -->
