### PR TITLE
fix(O3-4942) : fixed the flow of find patient tutorial

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -166,28 +166,18 @@ export const configSchema = {
             spotlightClicks: true,
             hideNextButton: true,
             data: {
-              autoNextOn: '[data-tutorial-target="patient-search-bar"]',
-            },
-          },
-          {
-            target: '[data-tutorial-target="patient-search-bar"]',
-            content:
-              'Now, enter the name of the patient here. If you know the patient ID, you can use that as well. You will see the results if the patient you entered exists in the system. Some example patient names that you can search for are: John, Smith, Mary.',
-            hideNextButton: true,
-            hideBackButton: true,
-            spotlightClicks: true,
-            data: {
-              autoNextOn: '[data-tutorial-target="floating-search-results-container"]',
+              autoNextOn: 'button[type="submit"]',
             },
           },
           {
             target: 'button[type="submit"]',
             content:
-              'If there are a lot of patients in the system, you may need additional fields to search other than the name. Also, the patient you are looking for may not be displayed in the top results if there are multiple patients with the same name. In these scenarios, you can click here to open the advanced search.',
+              'Now enter a name in input field, and If there are a lot of patients in the system, you may need additional fields to search other than the name. Also, the patient you are looking for may not be displayed in the top results if there are multiple patients with the same name. In these scenarios, you can click here to open the advanced search.',
             spotlightClicks: true,
             placement: 'bottom',
             hideNextButton: true,
             hideBackButton: true,
+            disableOverlay:true,
             data: {
               autoNextOn: '[data-openmrs-role="Refine Search"]',
             },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.  
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).  
- [x] My work includes tests or is validated by existing tests.  

## Summary  
Fixes **Find Patient tutorial** in `openmrs-esm-user-onboarding` where the tutorial step for entering a patient name could not interact with the input field because `autoNextOn` targeted `floating-search-results-container`.  

**Changes made:**  
- Removed the  step targeting the search input.  
- Updated the tutorial to point directly to the Search button.  
- where it tells the user to type a patient name in input field while pointing to the search button

This ensures users can manually type the patient name and continue without the tutorial flow breaking.  

## Related Issue  
https://openmrs.atlassian.net/browse/O3-4942  

## Other  
I feel like this is a partial fix. I want the tutorial to be more manual and include Next buttons for better control, but at present I’m still researching how React Joyride accesses components in the DOM. Currently, `autoNextOn` works, but the manual Next button does not.  