### PR TITLE
(chore) Migrate to rspack

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "source": true,
   "scripts": {
     "start": "openmrs develop",
-    "serve": "webpack serve --mode=development",
-    "build": "webpack --mode production",
-    "analyze": "webpack --mode=production --env analyze=true",
+    "serve": "rspack serve --mode=development",
+    "build": "rspack --mode production",
+    "analyze": "rspack --mode=production --env analyze=true",
     "lint": "eslint src --ext js,jsx,ts,tsx --max-warnings 0",
     "prettier": "prettier --write \"src/**/*.{ts,tsx}\" --list-different",
     "typescript": "tsc",
@@ -68,7 +68,6 @@
     "@types/react-dom": "^18.3.0",
     "@types/react-router": "^5.1.20",
     "@types/react-router-dom": "^5.3.3",
-    "@types/webpack-env": "^1.18.1",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "css-loader": "^6.8.1",
@@ -93,11 +92,8 @@
     "react-i18next": "^11.18.6",
     "react-router-dom": "^6.14.1",
     "rxjs": "^6.6.7",
-    "swc-loader": "^0.2.3",
     "turbo": "^2.5.2",
-    "typescript": "^5.0.0",
-    "webpack": "^5.99.9",
-    "webpack-cli": "^6.0.1"
+    "typescript": "^5.0.0"
   },
   "lint-staged": {
     "packages/**/src/**/*.{ts,tsx}": "eslint --cache --fix --max-warnings 0",

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -1,0 +1,1 @@
+module.exports = require('openmrs/default-rspack-config');

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,3 +1,17 @@
 declare module '*.css';
 declare module '*.scss';
 declare module '*.png';
+
+declare interface RequireContext {
+  keys(): string[];
+  (id: string): unknown;
+  <T>(id: string): T;
+  resolve(id: string): string;
+  id: string;
+}
+
+declare namespace NodeJS {
+  interface Require {
+    context(directory: string, useSubdirectories?: boolean, regExp?: RegExp, mode?: string): RequireContext;
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,1 +1,0 @@
-module.exports = require('openmrs/default-webpack-config');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2909,7 +2909,6 @@ __metadata:
     "@types/react-dom": "npm:^18.3.0"
     "@types/react-router": "npm:^5.1.20"
     "@types/react-router-dom": "npm:^5.3.3"
-    "@types/webpack-env": "npm:^1.18.1"
     "@typescript-eslint/eslint-plugin": "npm:^8.0.0"
     "@typescript-eslint/parser": "npm:^8.0.0"
     css-loader: "npm:^6.8.1"
@@ -2936,11 +2935,8 @@ __metadata:
     react-joyride: "npm:^2.8.2"
     react-router-dom: "npm:^6.14.1"
     rxjs: "npm:^6.6.7"
-    swc-loader: "npm:^0.2.3"
     turbo: "npm:^2.5.2"
     typescript: "npm:^5.0.0"
-    webpack: "npm:^5.99.9"
-    webpack-cli: "npm:^6.0.1"
   peerDependencies:
     "@openmrs/esm-framework": 9.x
     dayjs: 1.x
@@ -6274,13 +6270,6 @@ __metadata:
   version: 2.0.7
   resolution: "@types/trusted-types@npm:2.0.7"
   checksum: 10/8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
-  languageName: node
-  linkType: hard
-
-"@types/webpack-env@npm:^1.18.1":
-  version: 1.18.5
-  resolution: "@types/webpack-env@npm:1.18.5"
-  checksum: 10/3c8dd0b23d45e2d33abdfbae7f1d8f75ce23d54588b08943e833f4dba81eb683ac68672a75eccbdba8e008bc1647638803c1bcadc8cdfd1dd7142fa2c3f612de
   languageName: node
   linkType: hard
 
@@ -16147,7 +16136,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swc-loader@npm:0.2.7, swc-loader@npm:^0.2.3":
+"swc-loader@npm:0.2.7":
   version: 0.2.7
   resolution: "swc-loader@npm:0.2.7"
   dependencies:
@@ -17090,7 +17079,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-cli@npm:6.0.1, webpack-cli@npm:^6.0.1":
+"webpack-cli@npm:6.0.1":
   version: 6.0.1
   resolution: "webpack-cli@npm:6.0.1"
   dependencies:
@@ -17265,7 +17254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5.105.3, webpack@npm:^5.99.9":
+"webpack@npm:5.105.3":
   version: 5.105.3
   resolution: "webpack@npm:5.105.3"
   dependencies:


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Switch the bundler from webpack to rspack, matching the migration already landed across the rest of the distro.

- Rename `webpack.config.js` → `rspack.config.js` and require `openmrs/default-rspack-config`
- Update `package.json` `build` / `serve` / `analyze` scripts to call `rspack`
- Drop `@types/webpack-env` and declare `RequireContext` + `NodeJS.Require` locally in `src/declarations.d.ts` so `require.context` still type-checks
- Drop the direct `webpack`, `webpack-cli`, and `swc-loader` devDependencies. rspack ships its own CLI and integrates swc internally; none of these three packages are referenced from the build config.

## Screenshots

N/A — build tooling only.

## Related Issue

N/A.

## Other

Verified locally with `yarn build`, `yarn typescript`, and `yarn lint` — all green. Replaces #262, which had been opened against the wrong head branch.