### PR TITLE
(chore) Bump @openmrs/esm-framework peer dependency to 10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-joyride": "^2.8.2"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "9.x",
+    "@openmrs/esm-framework": "10.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "16.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2481,7 +2481,7 @@ __metadata:
     typescript: "npm:^5.0.0"
     vitest: "npm:^4.1.2"
   peerDependencies:
-    "@openmrs/esm-framework": 9.x
+    "@openmrs/esm-framework": 10.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 16.x


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
Bumps the `@openmrs/esm-framework` peer dependency from `9.x` to `10.x` (updated in both `package.json` and `yarn.lock`).

## Screenshots
<!-- Required if you are making UI changes. -->
N/A — no UI changes.

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->

## Other
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)