### PR TITLE
(chore)O3-5870: Add @carbon/react and @carbon/icons-react to peerDependencie…

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "react-joyride": "^2.8.2"
   },
   "peerDependencies": {
+    "@carbon/icons-react": "11.x",
+    "@carbon/react": "1.x",
     "@openmrs/esm-framework": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2481,6 +2481,8 @@ __metadata:
     typescript: "npm:^5.0.0"
     vitest: "npm:^4.1.2"
   peerDependencies:
+    "@carbon/icons-react": 11.x
+    "@carbon/react": 1.x
     "@openmrs/esm-framework": 10.x
     dayjs: 1.x
     react: 18.x


### PR DESCRIPTION
**What was changed:**
I added @carbon/react to peerDependencies, added @carbon/icons-react to peerDependencies, and also used version ranges matching those provided by the shell.
To allow the build tooling to automatically include both packages in the Module Federation shared configuration, prevents the app from bundling its own Carbon React and Carbon Icons runtime chunks and reduces duplicated Carbon-related code, which was previously measured at approximately 88 kB at runtimes in openmrs-esm-user-onboarding

**Issue Worked On:**
https://openmrs.atlassian.net/issues?filter=-6&selectedIssue=O3-5870