### PR TITLE
(chore) O3-5855: Declare react-dom as a peer dependency in esm-user-onboarding-app so it resolves as a shared singleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@openmrs/esm-framework": "10.x",
     "dayjs": "1.x",
     "react": "18.x",
+    "react-dom": "18.x",
     "react-i18next": "16.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2484,6 +2484,7 @@ __metadata:
     "@openmrs/esm-framework": 10.x
     dayjs: 1.x
     react: 18.x
+    react-dom: 18.x
     react-i18next: 16.x
     react-router-dom: 6.x
     rxjs: 6.x


### PR DESCRIPTION


## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

This PR addresses the issue where @openmrs/esm-user-onboarding-app does not declare react-dom as a peer dependency, causing the app to bundle and load its own copy of react-dom instead of using the shared Module Federation singleton provided by the app shell. This results in an unnecessary ~125 kB duplicate dependency being fetched on every page load. The PR adds react-dom: 18.x to peerDependencies, allowing the app to resolve react-dom from the shared singleton and reducing unnecessary bundle size and network usage.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/issues?filter=-6&selectedIssue=O3-5855

## Other
<!-- Anything not covered above -->
